### PR TITLE
utils crash 

### DIFF
--- a/src/CLADevs/VanillaX/items/ItemManager.php
+++ b/src/CLADevs/VanillaX/items/ItemManager.php
@@ -76,20 +76,17 @@ class ItemManager{
     }
 
     private function initializeCreativeItems(): void{
-        $oldCreativeItems = CreativeInventory::getInstance()->getAll();
-        CreativeInventory::getInstance()->clear();
-        $creativeItems = json_decode(file_get_contents(BEDROCK_DATA_PATH . "creativeitems.json"), true);
 
-        foreach($creativeItems as $data){
-            $item = Item::jsonDeserialize($data);
-            if($item->getName() === "Unknown"){
-                continue;
+        $old = CreativeInventory::getInstance();
+        CreativeInventory::reset();
+        $new = CreativeInventory::getInstance();
+
+        foreach($old->getAll() as $item){
+            if(!$new->contains($item)){
+                $new->add($item);
             }
-            CreativeInventory::getInstance()->add($item);
         }
-        foreach($oldCreativeItems as $item){
-            if(!CreativeInventory::getInstance()->contains($item)) CreativeInventory::getInstance()->add($item);
-        }
+
     }
 
     public static function register(Item $item, bool $creative = false, bool $overwrite = true): bool{

--- a/src/CLADevs/VanillaX/utils/Utils.php
+++ b/src/CLADevs/VanillaX/utils/Utils.php
@@ -3,7 +3,7 @@
 namespace CLADevs\VanillaX\utils;
 
 use CLADevs\VanillaX\VanillaX;
-use const pocketmine\BEDROCK_DATA_PATH;
+use const pocketmine\PATH;
 
 class Utils{
 

--- a/src/CLADevs/VanillaX/utils/Utils.php
+++ b/src/CLADevs/VanillaX/utils/Utils.php
@@ -37,16 +37,14 @@ class Utils{
      * @return int[]
      */
     public static function getBlockIdsMap(): array{
-        $file = "block_id_map.json";
-        return array_merge(json_decode(file_get_contents(BEDROCK_DATA_PATH . "/$file"), true), json_decode(file_get_contents(self::getResourceFile($file)), true));
+        return json_decode((string)file_get_contents(PATH . "vendor/pocketmine/bedrock-block-upgrade-schema/block_legacy_id_map.json"), true);
     }
 
     /**
      * @return int[]
      */
     public static function getItemIdsMap(): array{
-        $file = "item_id_map.json";
-        return array_merge(json_decode(file_get_contents(BEDROCK_DATA_PATH . "/$file"), true), json_decode(file_get_contents(self::getResourceFile($file)), true));
+        return json_decode((string)file_get_contents(PATH . "vendor/pocketmine/bedrock-item-upgrade-schema/item_legacy_id_map.json"), true);
     }
 
     public static function clamp(int|float $value, int|float $min, int|float $max): int|float{


### PR DESCRIPTION
When I run the plugin, an error like this came up:

Undefined constant "CLADevs\VanillaX\utils\PATH"" (EXCEPTION) in "plugins/VanillaX-4.0/src/CLADevs/VanillaX/utils/Utils" at line 40
--- Stack trace ---
  #0 plugins/VanillaX-4.0/src/CLADevs/VanillaX/configuration/features/BlockFeature(21): CLADevs\VanillaX\utils\Utils::getBlockIdsMap()
  #1 plugins/VanillaX-4.0/src/CLADevs/VanillaX/configuration/SettingManager(25): CLADevs\VanillaX\configuration\features\BlockFeature->__construct()
  #2 plugins/VanillaX-4.0/src/CLADevs/VanillaX/VanillaX(46): CLADevs\VanillaX\configuration\SettingManager->__construct()